### PR TITLE
Update lombok version, add proxy usage example

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,5 +59,14 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M
 rundeckProBuild=false
-lombokVersion=1.18.20
+lombokVersion=1.18.30
 okhttpVersion=4.12.0
+
+#systemProp.http.proxyHost=proxy.company.com
+#systemProp.http.proxyPort=<proxy port>
+#systemProp.https.proxyHost=proxy.company.com
+#systemProp.https.proxyPort=<proxy port>
+#systemProp.http.proxyUser=<user>
+#systemProp.http.proxyPassword=<password>
+#systemProp.https.proxyUser=<user>
+#systemProp.https.proxyPassword=<password>


### PR DESCRIPTION
Lombok version 1.18.20 exhibits the bug
java.lang.NullPointerException: Cannot read field "bindingsWhenTrue"  Fixed in 1.18.22 and later

**Is this a bugfix, or an enhancement? Please describe.**
Fix the bug `java.lang.NullPointerException: Cannot read field "bindingsWhenTrue" because "currentBindings" is null` which happens with lombok 1.18.20

**Describe the solution you've implemented**
As indicated in https://bugs.openjdk.org/browse/JDK-8280513 an upgrade of lombok fixes the problem
